### PR TITLE
Update intro.md

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -48,26 +48,33 @@ As there are no PyQt packages on PyPI for Linux/ARM, you will need to have your
 distro's PyQt5 packages already installed. Eg on Debian 11:
 
 ```
-$ sudo apt install python3-pyqt5.{qtwebengine,qtmultimedia}
+apt install python3-pyqt5.{qtwebengine,qtmultimedia}
 ```
 
 Or on Fedora:
 
 ```
-$ sudo dnf install python3-qt5-webengine
+dnf install python3-qt5-webengine
 ```
 
 Then run the following:
 
 ```
-$ python3.9 -m venv --system-site-packages pyenv
-$ pyenv/bin/pip install --upgrade pip
-$ pyenv/bin/pip install --upgrade --pre aqt
-$ pyenv/bin/anki
+python3 -m venv --system-site-packages pyenv
+```
+```
+pyenv/bin/pip install --upgrade pip
+```
+```
+pyenv/bin/pip install --upgrade aqt
+```
+```
+pyenv/bin/anki
 ```
 
 - Repeat the last step if you wish to start the same Anki version again.
 - Repeat the last two steps to update to the latest beta and start it.
+- Optionally if you want to install a beta add the `--pre` argument to installing aqt step 
 
 </details>
 


### PR DESCRIPTION
remove $ characters as they shouldn't be copied into the shell remove sudo as users should be able to know to add it if needed Split up the pyenv install steps so they can be copied individually make --pre optional as users might want stable
Change occurance of python3.9 to the ambiguous python3 as Debian 12 now packages Python3.11 instead

Edit: I've consulted this page a few times in the last few months and this is a set of changes I've been making before pasting into my shell. I also thought about adding directions for Qt6 builds  and also changing the installed directory name from `pyenv` to `anki`. The latter would involve me editing the windows and mac sections as well.